### PR TITLE
[HIPSPV] Preserve device debug info for gdb-oneapi

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPSPV.cpp
+++ b/clang/lib/Driver/ToolChains/HIPSPV.cpp
@@ -93,8 +93,24 @@ void HIPSPV::Linker::constructLinkAndEmitSpirvCommand(
   // We need 1.2 when using warp-level primitivies via sub group extensions.
   // Strictly put we'd need 1.3 for the standard non-extension shuffle
   // operations, but it's not supported by any target yet.
-  llvm::opt::ArgStringList TrArgs{"--spirv-max-version=1.2",
-                                  "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_EXT_shader_atomic_float_add,+SPV_EXT_relaxed_printf_string_address_space"};
+  std::string SpirvExts =
+      "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,"
+      "+SPV_EXT_shader_atomic_float_add,"
+      "+SPV_EXT_relaxed_printf_string_address_space";
+  llvm::opt::ArgStringList TrArgs{"--spirv-max-version=1.2"};
+  // When the user requests debug info (-g, but not -g0), preserve it into the
+  // SPIR-V in the NonSemantic.Shader.DebugInfo form. Intel's IGC and gdb-oneapi
+  // consume this to map device code back to source lines and local variables;
+  // the translator's default OpenCL.DebugInfo.100 form is not sufficient for
+  // that. Emitting the NonSemantic debug instructions requires the
+  // SPV_KHR_non_semantic_info extension, so it is only enabled here on demand
+  // to keep the default (non-debug) SPIR-V output unchanged.
+  if (const Arg *A = Args.getLastArg(options::OPT_g_Group);
+      A && !A->getOption().matches(options::OPT_g0)) {
+    SpirvExts += ",+SPV_KHR_non_semantic_info";
+    TrArgs.push_back("--spirv-debug-info-version=nonsemantic-shader-200");
+  }
+  TrArgs.push_back(Args.MakeArgString(SpirvExts));
   InputInfo TrInput = InputInfo(types::TY_LLVM_BC, TempFile, "");
   SPIRV::constructTranslateCommand(C, *this, JA, Output, TrInput, TrArgs);
 }
@@ -283,8 +299,15 @@ VersionTuple HIPSPVToolChain::computeMSVCVersion(const Driver *D,
 void HIPSPVToolChain::adjustDebugInfoKind(
     llvm::codegenoptions::DebugInfoKind &DebugInfoKind,
     const llvm::opt::ArgList &Args) const {
-  // Debug info generation is disabled for SPIRV-LLVM-Translator
-  // which currently aborts on the presence of DW_OP_LLVM_convert.
-  // TODO: Enable debug info when the SPIR-V backend arrives.
-  DebugInfoKind = llvm::codegenoptions::NoDebugInfo;
+  // Historically device debug info was force-disabled here because the
+  // SPIRV-LLVM-Translator aborted on DW_OP_LLVM_convert debug expressions.
+  // The translator now lowers that operation (SPIRVDebug::Convert), so honor
+  // the debug level the user requested (e.g. via -g) and let it flow into the
+  // emitted SPIR-V. constructLinkAndEmitSpirvCommand() additionally enables the
+  // NonSemantic.Shader.DebugInfo form at translation time so that Intel's IGC
+  // and gdb-oneapi can consume it. Leaving DebugInfoKind untouched keeps the
+  // default (no -g) behavior unchanged, since the driver defaults it to
+  // NoDebugInfo.
+  (void)DebugInfoKind;
+  (void)Args;
 }


### PR DESCRIPTION
`HIPSPVToolChain::adjustDebugInfoKind()` unconditionally forced `NoDebugInfo`, so `-g -O0` produced device SPIR-V with no debug metadata and gdb-oneapi could not resolve source lines or locals in kernels. The stated reason (SPIRV-LLVM-Translator aborting on `DW_OP_LLVM_convert`) no longer applies — the translator now lowers it to `SPIRVDebug::Convert`.

This honors the requested debug level and, when `-g` is given, emits the NonSemantic.Shader.DebugInfo form (`--spirv-debug-info-version=nonsemantic-shader-200` + `SPV_KHR_non_semantic_info`) that Intel IGC/gdb-oneapi consume. Non-`-g` output is unchanged.

Needs validation on Aurora (gdb-oneapi + PVC): build `-g -O0`, break in-kernel under `gdb-oneapi` with `ZET_ENABLE_PROGRAM_DEBUGGING=1`, confirm locals resolve, and confirm the translator does not abort.

Refs CHIP-SPV/chipStar#1004